### PR TITLE
Support for (pandas) record-oriented serialization

### DIFF
--- a/src/io/json/write/mod.rs
+++ b/src/io/json/write/mod.rs
@@ -5,8 +5,11 @@ mod utf8;
 pub use fallible_streaming_iterator::*;
 pub(crate) use serialize::new_serializer;
 use serialize::serialize;
+use std::io::Write;
 
-use crate::{array::Array, error::Error};
+use crate::{
+    array::Array, chunk::Chunk, datatypes::Schema, error::Error, io::iterator::StreamingIterator,
+};
 
 /// [`FallibleStreamingIterator`] that serializes an [`Array`] to bytes of valid JSON
 /// # Implementation
@@ -47,6 +50,79 @@ where
             .next()
             .map(|maybe_array| maybe_array.map(|array| serialize(array.as_ref(), &mut self.buffer)))
             .transpose()?;
+        Ok(())
+    }
+
+    fn get(&self) -> Option<&Self::Item> {
+        if !self.buffer.is_empty() {
+            Some(&self.buffer)
+        } else {
+            None
+        }
+    }
+}
+
+/// [`FallibleStreamingIterator`] that serializes a [`Chunk`] into bytes of JSON
+/// in a (pandas-compatible) record-oriented format.
+///
+/// # Implementation
+/// Advancing this iterator is CPU-bounded.
+pub struct RecordSerializer<'a> {
+    schema: Schema,
+    index: usize,
+    end: usize,
+    iterators: Vec<Box<dyn StreamingIterator<Item = [u8]> + Send + Sync + 'a>>,
+    buffer: Vec<u8>,
+}
+
+impl<'a> RecordSerializer<'a> {
+    /// Creates a new [`RecordSerializer`].
+    pub fn new<A>(schema: Schema, chunk: &'a Chunk<A>, buffer: Vec<u8>) -> Self
+    where
+        A: AsRef<dyn Array>,
+    {
+        let end = chunk.len();
+        let iterators = chunk
+            .arrays()
+            .iter()
+            .map(|arr| new_serializer(arr.as_ref()))
+            .collect();
+
+        Self {
+            schema,
+            index: 0,
+            end,
+            iterators,
+            buffer,
+        }
+    }
+}
+
+impl<'a> FallibleStreamingIterator for RecordSerializer<'a> {
+    type Item = [u8];
+
+    type Error = Error;
+
+    fn advance(&mut self) -> Result<(), Error> {
+        self.buffer.clear();
+        if self.index == self.end {
+            return Ok(());
+        }
+
+        let mut is_first_row = true;
+        write!(&mut self.buffer, "{{")?;
+        for (f, ref mut it) in self.schema.fields.iter().zip(self.iterators.iter_mut()) {
+            if !is_first_row {
+                write!(&mut self.buffer, ",")?;
+            }
+            write!(&mut self.buffer, "\"{}\":", f.name)?;
+
+            self.buffer.extend_from_slice(it.next().unwrap());
+            is_first_row = false;
+        }
+        write!(&mut self.buffer, "}}")?;
+
+        self.index += 1;
         Ok(())
     }
 

--- a/tests/it/io/json/mod.rs
+++ b/tests/it/io/json/mod.rs
@@ -2,11 +2,21 @@ mod read;
 mod write;
 
 use arrow2::array::*;
+use arrow2::chunk::Chunk;
+use arrow2::datatypes::Schema;
 use arrow2::error::Result;
 use arrow2::io::json::write as json_write;
 
 fn write_batch(array: Box<dyn Array>) -> Result<Vec<u8>> {
     let mut serializer = json_write::Serializer::new(vec![Ok(array)].into_iter(), vec![]);
+
+    let mut buf = vec![];
+    json_write::write(&mut buf, &mut serializer)?;
+    Ok(buf)
+}
+
+fn write_record_batch<A: AsRef<dyn Array>>(schema: Schema, chunk: Chunk<A>) -> Result<Vec<u8>> {
+    let mut serializer = json_write::RecordSerializer::new(schema, &chunk, vec![]);
 
     let mut buf = vec![];
     json_write::write(&mut buf, &mut serializer)?;


### PR DESCRIPTION
This is pretty straightforward. Individual streaming iterators already produce a record at a time, so we just need to salami slice them to transpose the results.