### PR TITLE
JSON (pandas) record-oriented deserialization

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -1,7 +1,9 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
-    array::{specification::check_offsets, Array, MutableArray, Offset, TryExtend, TryPush},
+    array::{
+        specification::check_offsets, Array, MutableArray, Offset, Preallocate, TryExtend, TryPush,
+    },
     bitmap::MutableBitmap,
     datatypes::DataType,
     error::{Error, Result},
@@ -183,6 +185,12 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// returns its offsets.
     pub fn offsets(&self) -> &Vec<O> {
         &self.offsets
+    }
+}
+
+impl<O: Offset> Preallocate for MutableBinaryArray<O> {
+    fn with_capacity(capacity: usize) -> Self {
+        MutableBinaryArray::with_capacity(capacity)
     }
 }
 

--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -2,7 +2,7 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, MutableArray, TryExtend, TryPush},
+    array::{Array, MutableArray, Preallocate, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::{DataType, PhysicalType},
     error::Result,
@@ -450,6 +450,12 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> FromIterator<Ptr> for MutableBoolea
             .collect();
 
         MutableBooleanArray::from_data(DataType::Boolean, values, validity.into())
+    }
+}
+
+impl Preallocate for MutableBooleanArray {
+    fn with_capacity(capacity: usize) -> Self {
+        MutableBooleanArray::with_capacity(capacity)
     }
 }
 

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, MutableArray},
+    array::{Array, MutableArray, Preallocate},
     bitmap::MutableBitmap,
     datatypes::DataType,
     error::{Error, Result},
@@ -194,6 +194,12 @@ impl MutableFixedSizeBinaryArray {
     /// Returns a mutable slice of values.
     pub fn values_mut_slice(&mut self) -> &mut [u8] {
         self.values.as_mut_slice()
+    }
+}
+
+impl Preallocate for MutableFixedSizeBinaryArray {
+    fn with_capacity(capacity: usize) -> Self {
+        MutableFixedSizeBinaryArray::with_capacity(capacity, 0)
     }
 }
 

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, MutableArray, Offset, TryExtend, TryPush},
+    array::{Array, MutableArray, Offset, Preallocate, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::{DataType, Field},
     error::{Error, Result},
@@ -200,6 +200,12 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         if let Some(validity) = &mut self.validity {
             validity.shrink_to_fit()
         }
+    }
+}
+
+impl<O: Offset, M: MutableArray + Default + 'static> Preallocate for MutableListArray<O, M> {
+    fn with_capacity(capacity: usize) -> Self {
+        MutableListArray::with_capacity(capacity)
     }
 }
 

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -1,10 +1,14 @@
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, MutableArray, Offset, Preallocate, TryExtend, TryPush},
+    array::{
+        specification::try_check_offsets, Array, MutableArray, Offset, Preallocate, TryExtend,
+        TryPush,
+    },
     bitmap::MutableBitmap,
     datatypes::{DataType, Field},
     error::{Error, Result},
+    trusted_len::TrustedLen,
 };
 
 use super::ListArray;
@@ -152,6 +156,69 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         }
     }
 
+    /// Expand this array, using elements from the underlying backing array.
+    /// Assumes the expansion begins at the highest previous offset, or zero if
+    /// this [MutableListArray] is currently empty.
+    ///
+    /// Panics if:
+    /// - the new offsets are not in monotonic increasing order.
+    /// - any new offset is not in bounds of the backing array.
+    /// - the passed iterator has no upper bound.
+    pub fn expand<II>(&mut self, expansion: II)
+    where
+        II: IntoIterator<Item = Option<O>> + TrustedLen,
+    {
+        let current_len = self.offsets.len();
+        let (_, upper) = expansion.size_hint();
+        let upper = upper.expect("iterator must have upper bound");
+        if current_len == 0 && upper > 0 {
+            self.offsets.push(O::zero());
+        }
+        // safety: checked below
+        unsafe { self.unsafe_expand(expansion) };
+        if self.offsets.len() > current_len {
+            // check all inserted offsets
+            try_check_offsets(&self.offsets[current_len..], self.values.len())
+                .expect("invalid offsets");
+        }
+        // else expansion is empty, and this is trivially safe.
+    }
+
+    /// Expand this array. Assumes that `offsets` are in order, and do not
+    /// overrun the underlying `values` backing array.
+    ///
+    /// Also assumes the expansion begins at the highest previous offset, or
+    /// zero if the array is currently empty.
+    ///
+    /// Panics if the passed iterator has no upper bound.
+    pub unsafe fn unsafe_expand<II>(&mut self, expansion: II)
+    where
+        II: IntoIterator<Item = Option<O>> + TrustedLen,
+    {
+        let (_, upper) = expansion.size_hint();
+        let upper = upper.expect("iterator must have upper bound");
+        let final_size = self.len() + upper;
+        self.offsets.reserve(upper);
+
+        for item in expansion {
+            match item {
+                Some(offset) => {
+                    self.offsets.push(offset);
+                    if let Some(validity) = &mut self.validity {
+                        validity.push(true);
+                    }
+                }
+                None => self.push_null(),
+            }
+
+            if let Some(validity) = &mut self.validity {
+                if validity.capacity() < final_size {
+                    validity.reserve(final_size - validity.capacity());
+                }
+            }
+        }
+    }
+
     /// The values
     pub fn mut_values(&mut self) -> &mut M {
         &mut self.values
@@ -201,6 +268,10 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
             validity.shrink_to_fit()
         }
     }
+
+    fn len(&self) -> usize {
+        self.offsets.len() - 1
+    }
 }
 
 impl<O: Offset, M: MutableArray + Default + 'static> Preallocate for MutableListArray<O, M> {
@@ -211,7 +282,7 @@ impl<O: Offset, M: MutableArray + Default + 'static> Preallocate for MutableList
 
 impl<O: Offset, M: MutableArray + 'static> MutableArray for MutableListArray<O, M> {
     fn len(&self) -> usize {
-        self.offsets.len() - 1
+        MutableListArray::len(self)
     }
 
     fn validity(&self) -> Option<&MutableBitmap> {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -113,6 +113,15 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
 
 dyn_clone::clone_trait_object!(Array);
 
+/// A trait describing an array with a backing store that can be preallocated to
+/// a given size.
+pub trait Preallocate {
+    /// Create this array with a given capacity.
+    fn with_capacity(capacity: usize) -> Self
+    where
+        Self: Sized;
+}
+
 /// A trait describing a mutable array; i.e. an array whose values can be changed.
 /// Mutable arrays cannot be cloned but can be mutated in place,
 /// thereby making them useful to perform numeric operations without allocations.

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -17,6 +17,7 @@
 //! Most arrays contain a [`MutableArray`] counterpart that is neither clonable nor slicable, but
 //! can be operated in-place.
 use std::any::Any;
+use std::sync::Arc;
 
 use crate::error::Result;
 use crate::{
@@ -174,6 +175,45 @@ pub trait MutableArray: std::fmt::Debug + Send + Sync {
 
     /// Shrink the array to fit its length.
     fn shrink_to_fit(&mut self);
+}
+
+impl MutableArray for Box<dyn MutableArray> {
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.as_ref().validity()
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        self.as_mut().as_box()
+    }
+
+    fn as_arc(&mut self) -> Arc<dyn Array> {
+        self.as_mut().as_arc()
+    }
+
+    fn data_type(&self) -> &DataType {
+        self.as_ref().data_type()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.as_ref().as_any()
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self.as_mut().as_mut_any()
+    }
+
+    #[inline]
+    fn push_null(&mut self) {
+        self.as_mut().push_null()
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.as_mut().shrink_to_fit();
+    }
 }
 
 macro_rules! general_dyn {

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -2,7 +2,7 @@ use std::{iter::FromIterator, sync::Arc};
 
 use crate::bitmap::Bitmap;
 use crate::{
-    array::{Array, MutableArray, TryExtend, TryPush},
+    array::{Array, MutableArray, Preallocate, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::DataType,
     error::{Error, Result},
@@ -375,6 +375,12 @@ impl<T: NativeType> TryPush<Option<T>> for MutablePrimitiveArray<T> {
     fn try_push(&mut self, item: Option<T>) -> Result<()> {
         self.push(item);
         Ok(())
+    }
+}
+
+impl<T: NativeType> Preallocate for MutablePrimitiveArray<T> {
+    fn with_capacity(capacity: usize) -> Self {
+        MutablePrimitiveArray::with_capacity(capacity)
     }
 }
 

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -3,7 +3,7 @@ use std::{iter::FromIterator, sync::Arc};
 use crate::{
     array::{
         specification::{check_offsets_minimal, try_check_offsets_and_utf8},
-        Array, MutableArray, Offset, TryExtend, TryPush,
+        Array, MutableArray, Offset, Preallocate, TryExtend, TryPush,
     },
     bitmap::MutableBitmap,
     datatypes::DataType,
@@ -252,6 +252,12 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// returns its offsets.
     pub fn offsets(&self) -> &Vec<O> {
         &self.offsets
+    }
+}
+
+impl<O: Offset> Preallocate for MutableUtf8Array<O> {
+    fn with_capacity(capacity: usize) -> Self {
+        MutableUtf8Array::with_capacity(capacity)
     }
 }
 

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -6,7 +6,7 @@ use indexmap::set::IndexSet as HashSet;
 use json_deserializer::{Number, Value};
 
 use crate::datatypes::*;
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 const ITEM_NAME: &str = "item";
 
@@ -19,6 +19,46 @@ pub fn infer(json: &Value) -> Result<DataType> {
         Value::Number(number) => infer_number(number),
         Value::String(_) => DataType::Utf8,
         Value::Object(inner) => infer_object(inner)?,
+    })
+}
+
+/// Infers [`Schema`] from JSON [`Value`] in (pandas-compatible) records format.
+pub fn infer_records_schema(json: &Value) -> Result<Schema> {
+    let outer_array = match json {
+        Value::Array(array) => Ok(array),
+        _ => Err(Error::ExternalFormat(
+            "outer type is not an array".to_string(),
+        )),
+    }?;
+
+    let fields = match outer_array.iter().next() {
+        Some(Value::Object(record)) => record
+            .iter()
+            .map(|(name, json)| {
+                let data_type = infer(json)?;
+
+                Ok(Field {
+                    name: name.clone(),
+                    data_type: DataType::List(Box::new(Field {
+                        name: format!("{}-records", name),
+                        data_type,
+                        is_nullable: true,
+                        metadata: Metadata::default(),
+                    })),
+                    is_nullable: true,
+                    metadata: Metadata::default(),
+                })
+            })
+            .collect::<Result<Vec<_>>>(),
+        None => Ok(vec![]),
+        _ => Err(Error::ExternalFormat(
+            "first element in array is not a record".to_string(),
+        )),
+    }?;
+
+    Ok(Schema {
+        fields,
+        metadata: Metadata::default(),
     })
 }
 

--- a/src/io/json/read/mod.rs
+++ b/src/io/json/read/mod.rs
@@ -3,8 +3,8 @@ mod deserialize;
 mod infer_schema;
 
 pub(crate) use deserialize::_deserialize;
-pub use deserialize::deserialize;
+pub use deserialize::{deserialize, deserialize_records};
 pub(crate) use infer_schema::coerce_data_type;
-pub use infer_schema::infer;
+pub use infer_schema::{infer, infer_records_schema};
 
 pub use json_deserializer;

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -33,3 +33,86 @@ fn read_json() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn read_json_records() -> Result<()> {
+    let data = br#"[
+        {
+            "a": [
+                [1.1, 2, 3],
+                [2, 3],
+                [4, 5, 6]
+            ],
+            "b": [1, 2, 3]
+        },
+        {
+            "a": [
+                [3, 2, 1],
+                [3, 2],
+                [6, 5, 4]
+            ]
+        },
+        {
+            "b": [7, 8, 9]
+        }
+    ]"#;
+
+    let a_iter = vec![
+        vec![
+            Some(vec![Some(1.1), Some(2.), Some(3.)]),
+            Some(vec![Some(2.), Some(3.)]),
+            Some(vec![Some(4.), Some(5.), Some(6.)]),
+        ],
+        vec![
+            Some(vec![Some(3.), Some(2.), Some(1.)]),
+            Some(vec![Some(3.), Some(2.)]),
+            Some(vec![Some(6.), Some(5.), Some(4.)]),
+        ],
+    ];
+
+    let a_iter = a_iter.into_iter().map(Some);
+    let a_inner = MutableListArray::<i32, MutablePrimitiveArray<f64>>::new_with_field(
+        MutablePrimitiveArray::<f64>::new(),
+        "inner",
+        false,
+    );
+    let mut a_outer =
+        MutableListArray::<i32, MutableListArray<i32, MutablePrimitiveArray<f64>>>::new_with_field(
+            a_inner, "a", false,
+        );
+    a_outer.try_extend(a_iter).unwrap();
+    let a_expected: ListArray<i32> = a_outer.into();
+
+    let b_iter = vec![
+        vec![Some(1), Some(2), Some(3)],
+        vec![Some(7), Some(8), Some(9)],
+    ];
+    let b_iter = b_iter.into_iter().map(Some);
+    let mut b = MutableListArray::<i32, MutablePrimitiveArray<i64>>::new_with_field(
+        MutablePrimitiveArray::<i64>::new(),
+        "b",
+        false,
+    );
+    b.try_extend(b_iter).unwrap();
+    let b_expected: ListArray<i32> = b.into();
+
+    let json = json_deserializer::parse(data)?;
+
+    let schema = read::infer_records_schema(&json)?;
+    let actual = read::deserialize_records(&json, &schema)?;
+
+    for (f, arr) in schema.fields.iter().zip(actual.arrays().iter()) {
+        let (expected, actual) = if f.name == "a" {
+            (&a_expected, arr.as_ref())
+        } else if f.name == "b" {
+            (&b_expected, arr.as_ref())
+        } else {
+            panic!("unexpected field found: {}", f.name);
+        };
+
+        // No idea why assert_eq! doesn't work here, but this does.
+        assert_eq!(format!("{:?}", expected), format!("{:?}", actual));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This one was more complicated than serialization (#1). The general thrust:

- Define `Preallocate` for arrays that have a backing that can be opportunistically resized.
- Add `expand` to `MutableListArray`. This is the workhorse that makes later arbitrarily-nested deserialization possible.
- Declare an `impl MutableArray` for `Box<dyn MutableArray>`. This is mostly trivial delegation, so it may be worth investigating the [`delegate` crate](https://docs.rs/delegate/latest/delegate/) for boilerplate reduction. We need this to support arbitrary recursion at the type level. This allows us to define a `MutableListArray<O, Box<dyn MutableArray>>`.
- Finally, implement schema inference and deserialization. Here be dragons:
  - Schema inference basically recurses down to the first element for each list, and assumes that element and array shape for all future records. There are obvious pitfalls here.
  - For deserialization, we want to avoid an expensive transpose. So we instead allocate mutable arrays for each record in the schema, and `expand` any nested list arrays recursively after filling the recursive sub-level. This requires converting a bunch of `deserialize_xxx` methods into `deserialize_xxx_into` methods that extend an existing array instead of returning a new array. We can generally use adapters like `fill_array_from` to avoid code duplication in the original case where we just need a plain list returned.

This PR only handles the types we imminently care about, and is narrowly focused in a few other ways. I'd like to sync back with upstream and verify the general approach here before bulletproofing this code. In particular, there are more `todo!`s than I'd like to have long term. Note that this is the approach taken upstream, so the entire `io::json::read::deserialize` module may need a general round of `todo!` cleanup, or at least conversion into concrete `NotYetImplemented` errors.