### PR TITLE
Support fixed-size list ser/de for json records

### DIFF
--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -59,6 +59,11 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
         }
     }
 
+    /// Returns the size (number of elements per slot) of this [`FixedSizeListArray`].
+    pub const fn size(&self) -> usize {
+        self.size
+    }
+
     /// The inner values
     pub fn values(&self) -> &M {
         &self.values

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -572,35 +572,31 @@ pub fn deserialize(json: &Value, data_type: DataType) -> Result<Box<dyn Array>, 
 }
 
 fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
-    fn allocate_inner(f: &Field) -> Box<dyn MutableArray> {
-        match f.data_type() {
-            DataType::Int8 => Box::new(MutablePrimitiveArray::<i8>::new()),
-            DataType::Int16 => Box::new(MutablePrimitiveArray::<i16>::new()),
-            DataType::Int32 => Box::new(MutablePrimitiveArray::<i32>::new()),
-            DataType::Int64 => Box::new(MutablePrimitiveArray::<i64>::new()),
-            DataType::UInt8 => Box::new(MutablePrimitiveArray::<u8>::new()),
-            DataType::UInt16 => Box::new(MutablePrimitiveArray::<u16>::new()),
-            DataType::UInt32 => Box::new(MutablePrimitiveArray::<u32>::new()),
-            DataType::UInt64 => Box::new(MutablePrimitiveArray::<u64>::new()),
-            DataType::Float16 => Box::new(MutablePrimitiveArray::<f16>::new()),
-            DataType::Float32 => Box::new(MutablePrimitiveArray::<f32>::new()),
-            DataType::Float64 => Box::new(MutablePrimitiveArray::<f64>::new()),
-            DataType::List(..) => allocate_array(f),
-            DataType::FixedSizeList(..) => allocate_array(f),
-            _ => todo!(),
-        }
-    }
     match f.data_type() {
-        DataType::List(inner) => Box::new(MutableListArray::<i32, _>::new_from(
+        DataType::Int8 => Box::new(MutablePrimitiveArray::<i8>::new()),
+        DataType::Int16 => Box::new(MutablePrimitiveArray::<i16>::new()),
+        DataType::Int32 => Box::new(MutablePrimitiveArray::<i32>::new()),
+        DataType::Int64 => Box::new(MutablePrimitiveArray::<i64>::new()),
+        DataType::UInt8 => Box::new(MutablePrimitiveArray::<u8>::new()),
+        DataType::UInt16 => Box::new(MutablePrimitiveArray::<u16>::new()),
+        DataType::UInt32 => Box::new(MutablePrimitiveArray::<u32>::new()),
+        DataType::UInt64 => Box::new(MutablePrimitiveArray::<u64>::new()),
+        DataType::Float16 => Box::new(MutablePrimitiveArray::<f16>::new()),
+        DataType::Float32 => Box::new(MutablePrimitiveArray::<f32>::new()),
+        DataType::Float64 => Box::new(MutablePrimitiveArray::<f64>::new()),
+        DataType::FixedSizeList(inner, size) => Box::new(MutableFixedSizeListArray::<_>::new_from(
             allocate_array(inner),
-            f.data_type().clone(),
-            0,
-        )),
-        DataType::FixedSizeList(child, size) => Box::new(MutableFixedSizeListArray::<_>::new_from(
-            allocate_inner(child),
             f.data_type().clone(),
             *size,
         )),
+        DataType::List(inner) => match inner.data_type() {
+            DataType::List(_) => Box::new(MutableListArray::<i32, _>::new_from(
+                allocate_array(inner),
+                inner.data_type().clone(),
+                0,
+            )),
+            _ => allocate_array(inner),
+        },
         _ => todo!(),
     }
 }


### PR DESCRIPTION
I'm curious if we can avoid allocations by porting the approach in `deserialize_fixed_size_list_into` over to `deserialize_list_into`. But we don't need to do that right now, I'll leave it for a possible future PR.