### PR TITLE
Fix list array parsing in pandas record json

### DIFF
--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -638,14 +638,11 @@ fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
             f.data_type().clone(),
             *size,
         )),
-        DataType::List(inner) => match inner.data_type() {
-            DataType::List(_) => Box::new(MutableListArray::<i32, _>::new_from(
-                allocate_array(inner),
-                inner.data_type().clone(),
-                0,
-            )),
-            _ => allocate_array(inner),
-        },
+        DataType::List(inner) => Box::new(MutableListArray::<i32, _>::new_from(
+            allocate_array(inner),
+            f.data_type().clone(),
+            0,
+        )),
         _ => todo!(),
     }
 }

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -38,12 +38,7 @@ pub fn infer_records_schema(json: &Value) -> Result<Schema> {
 
                 Ok(Field {
                     name: name.clone(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: format!("{}-records", name),
-                        data_type,
-                        is_nullable: true,
-                        metadata: Metadata::default(),
-                    })),
+                    data_type,
                     is_nullable: true,
                     metadata: Metadata::default(),
                 })

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -195,3 +195,32 @@ fn read_json_fixed_size_records() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn read_json_records_with_schema() -> Result<()> {
+    let raw = b"[{\"matrix\":[0.0,2.0]},{\"matrix\":[0.0,0.0,2.1,3.0]}]";
+    let schema = Schema {
+        fields: vec![Field::new(
+            "matrix",
+            DataType::List(Box::new(Field::new("inner", DataType::Float32, false))),
+            false,
+        )],
+        metadata: Metadata::default(),
+    };
+
+    let json = json_deserializer::parse(raw)?;
+    let actual = read::deserialize_records(&json, &schema)?;
+    assert_eq!(
+        format!("{:?}", actual.arrays()[0]),
+        "ListArray[[0, 2], [0, 0, 2.1, 3]]"
+    );
+
+    let schema = read::infer_records_schema(&json)?;
+    let actual = read::deserialize_records(&json, &schema)?;
+    assert_eq!(
+        format!("{:?}", actual.arrays()[0]),
+        "ListArray[[0, 2], [0, 0, 2.1, 3]]"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
I don't know why I introduced this duplicate level of nesting; probably because I knew much less about arrow back then.

It doesn't belong and it breaks things.